### PR TITLE
feat(dispatcher): modernize accounts dispatcher to Gen 2 and add unit…

### DIFF
--- a/src/common_requirements.txt
+++ b/src/common_requirements.txt
@@ -1,0 +1,6 @@
+functions-framework==3.10.2
+google-auth==2.56.2
+google-api-python-client==2.198.0
+google-cloud-logging==3.16.1
+google-cloud-pubsub==2.39.0
+jsonschema==4.26.0

--- a/src/google-ads-accounts-dispatcher/main.py
+++ b/src/google-ads-accounts-dispatcher/main.py
@@ -1,0 +1,225 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fetch the Google Ads configs and push them to pub/sub."""
+
+import os
+from typing import Any
+
+import flask
+import functions_framework
+import google.auth
+from googleapiclient import discovery
+import jsonschema
+from vet_common.ids import sanitize_gads_id
+from vet_common.logging import get_service_logger
+from vet_common.pubsub import publish_batch
+
+logger = get_service_logger()
+
+# The Google Cloud project containing the pub/sub topic
+GOOGLE_CLOUD_PROJECT = os.environ.get('GOOGLE_CLOUD_PROJECT')
+ACCOUNT_PUBSUB_TOPIC = os.environ.get('VET_GOOGLE_ADS_ACCOUNT_TOPIC')
+
+# The access scopes used in this function
+SCOPES = ['https://www.googleapis.com/auth/spreadsheets.readonly']
+
+# The schema of the JSON in the request
+REQUEST_SCHEMA = {
+    'type': 'object',
+    'properties': {
+        'sheet_id': {'type': 'string'},
+    },
+    'required': [
+        'sheet_id',
+    ],
+}
+
+
+def _get_config_from_sheet(sheet_id: str) -> list[dict[str, Any]]:
+  """Gets the Ads account config from the Google Sheet, and return the results.
+
+  Args:
+      sheet_id: The ID of the Google Sheet containing the config.
+
+  Returns:
+      A row for each account a report needs to be run for.
+
+      [
+          {
+              'sheet_id': 'abcdefghijklmnop-mk',
+              'customer_id': '1234567890',
+              'mcc_for_exclusions': '5555555555',
+              'lookback_days': 90,
+              'gads_filters': 'clicks > 10',
+              'settings': {
+                  'foo': 'bar',
+                  'baz': 'qux',
+              }
+          },
+          ...
+      ]
+  """
+  logger.info('Getting config from sheet: %s', sheet_id)
+  credentials, _ = google.auth.default(scopes=SCOPES)
+  sheets_service = discovery.build(
+      serviceName='sheets',
+      version='v4',
+      credentials=credentials,
+      cache_discovery=False,
+  )
+  sheet = sheets_service.spreadsheets()
+
+  customer_ids = (
+      sheet.values()
+      .get(spreadsheetId=sheet_id, range='google_ads_customer_ids')
+      .execute()
+      .get('values', [])
+  )
+  gads_filters = (
+      sheet.values()
+      .get(spreadsheetId=sheet_id, range='google_ads_filters')
+      .execute()
+      .get('values', [])
+  )
+  lookback_days_values = (
+      sheet.values()
+      .get(spreadsheetId=sheet_id, range='google_ads_lookback_days')
+      .execute()
+      .get('values', [['1']])
+  )
+  lookback_days = (
+      lookback_days_values[0][0]
+      if lookback_days_values and lookback_days_values[0]
+      else '1'
+  )
+  config = (
+      sheet.values()
+      .get(spreadsheetId=sheet_id, range='configuration')
+      .execute()
+      .get('values', [])
+  )
+
+  gads_filters_str = _gads_filters_to_gaql_string(gads_filters)
+
+  logger.info('Returned %i customer_ids', len(customer_ids))
+  account_configs = []
+  for row in customer_ids:
+    if len(row) < 2:
+      continue
+    customer_id = row[0]
+    is_enabled = row[1]
+    mcc_for_exclusions = row[2] if len(row) >= 3 else ''
+    if is_enabled == 'Enabled':
+      account_configs.append({
+          'sheet_id': sheet_id,
+          'customer_id': sanitize_gads_id(customer_id),
+          'mcc_for_exclusions': sanitize_gads_id(mcc_for_exclusions),
+          'lookback_days': int(lookback_days),
+          'gads_filters': gads_filters_str,
+          'settings': {item[0]: item[1] for item in config if len(item) >= 2},
+      })
+    else:
+      logger.info('Ignoring disabled row: %s', customer_id)
+
+  logger.info('Account configs:')
+  logger.info(account_configs)
+  return account_configs
+
+
+def _gads_filters_to_gaql_string(config_filters: list[list[str]]) -> str:
+  """Turns the Google Ads filters into a GAQL compatible string.
+
+  The config sheet has the filters in a list of lists, these need to be
+  combined, so they can be used in a WHERE clause in the GAQL that is passed
+  to Google Ads. See:
+  https://developers.google.com/google-ads/api/docs/query/overview
+
+  Each row is "AND" together.
+
+  Args:
+      config_filters: The filters from the Google Sheet.
+
+  Returns:
+      A string that can be used in the WHERE statement of the Google Ads Query
+      Language.
+  """
+  conditions = []
+  for row in config_filters:
+    if len(row) >= 3:
+      conditions.append(f'metrics.{row[0]} {row[1]} {row[2]}')
+  return ' AND '.join(conditions)
+
+
+def run(sheet_id: str) -> None:
+  """Orchestration for the function.
+
+  Args:
+      sheet_id: the ID of the Google Sheet containing the config.
+  """
+  logger.info('Running Google Ads account script')
+  publish_batch(
+      project_id=GOOGLE_CLOUD_PROJECT,
+      topic_id=ACCOUNT_PUBSUB_TOPIC,
+      messages=_get_config_from_sheet(sheet_id),
+      logger=logger,
+  )
+  logger.info('Done.')
+
+
+@functions_framework.http
+def main(request: flask.Request) -> flask.Response:
+  """The entry point: extract the data from the payload and starts the job.
+
+  The request payload must match the request_schema object above.
+
+  Args:
+      request (flask.Request): HTTP request object.
+
+  Returns:
+      The flask response.
+  """
+  logger.info('Google Ads Account dispatch triggered.')
+
+  request_json = request.get_json(silent=True)
+  logger.info('JSON payload: %s', request_json)
+  response = {}
+  try:
+    jsonschema.validate(instance=request_json, schema=REQUEST_SCHEMA)
+  except jsonschema.exceptions.ValidationError as err:
+    logger.error('Invalid request payload: %s', err)
+    response['status'] = 'Failed'
+    response['message'] = err.message
+    return flask.Response(
+        flask.json.dumps(response), status=400, mimetype='application/json'
+    )
+
+  try:
+    run(request_json['sheet_id'])
+  except Exception as err:  # pylint: disable=broad-except
+    logger.error('Failed to run Google Ads account script: %s', err)
+    response['status'] = 'Failed'
+    response['message'] = str(err)
+    return flask.Response(
+        flask.json.dumps(response), status=500, mimetype='application/json'
+    )
+
+  response['status'] = 'Success'
+  response['message'] = 'Google Ads Account dispatch finished.'
+
+  logger.info('Google Ads Account dispatch finished.')
+
+  return flask.Response(
+      flask.json.dumps(response), status=200, mimetype='application/json'
+  )

--- a/src/google-ads-accounts-dispatcher/requirements.txt
+++ b/src/google-ads-accounts-dispatcher/requirements.txt
@@ -1,0 +1,1 @@
+# All baseline dependencies are provided by src/common_requirements.txt

--- a/src/google-ads-accounts-dispatcher/tests/conftest.py
+++ b/src/google-ads-accounts-dispatcher/tests/conftest.py
@@ -1,0 +1,63 @@
+"""Pytest configuration for the google-ads-accounts-dispatcher module."""
+
+import os
+import sys
+
+TEST_SHEET_ID = 'test_sheet_123'
+TEST_PROJECT_ID = 'test-gcp-project'
+TEST_TOPIC_ID = 'test-topic'
+
+project_root_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, project_root_dir)
+src_dir = os.path.dirname(project_root_dir)
+if src_dir not in sys.path:
+  sys.path.insert(0, src_dir)
+print(f'\n[conftest.py] Added to sys.path: {project_root_dir}, {src_dir}')
+
+_original_env_vars = {}
+_env_vars_to_manage = [
+    'IS_LOCAL_TEST',
+    'GOOGLE_CLOUD_PROJECT',
+    'VET_GOOGLE_ADS_ACCOUNT_TOPIC',
+    'K_SERVICE',
+]
+
+TEST_SESSION_ENV_VALUES = {
+    'IS_LOCAL_TEST': 'True',
+    'GOOGLE_CLOUD_PROJECT': TEST_PROJECT_ID,
+    'VET_GOOGLE_ADS_ACCOUNT_TOPIC': TEST_TOPIC_ID,
+    'K_SERVICE': 'test-gads-account-dispatcher',
+}
+
+
+def pytest_configure(config):
+  """Sets up the environment for testing."""
+  del config  # Unused
+  print(
+      '[conftest.py:pytest_configure] Setting environment variables for'
+      ' google-ads-accounts-dispatcher test session.'
+  )
+  for key in _env_vars_to_manage:
+    _original_env_vars[key] = os.environ.get(key)
+    if key in TEST_SESSION_ENV_VALUES:
+      os.environ[key] = TEST_SESSION_ENV_VALUES[key]
+      print(f"  Set: {key} = '{TEST_SESSION_ENV_VALUES[key]}'")
+
+
+def pytest_unconfigure(config):
+  """Cleans up the environment after testing."""
+  del config  # Unused
+  print(
+      '[conftest.py:pytest_unconfigure] Restoring original environment'
+      ' variables.'
+  )
+  for key in _env_vars_to_manage:
+    original_value = _original_env_vars.get(key)
+    if original_value is None:
+      if key in os.environ:
+        del os.environ[key]
+        print(f'  Removed: {key}')
+    else:
+      os.environ[key] = original_value
+      print(f'  Restored: {key} = "{original_value}"')
+  _original_env_vars.clear()

--- a/src/google-ads-accounts-dispatcher/tests/test_dispatcher_main.py
+++ b/src/google-ads-accounts-dispatcher/tests/test_dispatcher_main.py
@@ -1,0 +1,190 @@
+"""Unit tests for google-ads-accounts-dispatcher main module."""
+
+# pylint: disable=protected-access
+
+import importlib.util
+import json
+import pathlib
+import sys
+from unittest import mock
+
+import flask
+
+_project_dir = pathlib.Path(__file__).resolve().parent.parent
+_spec = importlib.util.spec_from_file_location(
+    'dispatcher_main', _project_dir / 'main.py'
+)
+main = importlib.util.module_from_spec(_spec)
+sys.modules['dispatcher_main'] = main
+_spec.loader.exec_module(main)
+
+
+def test_gads_filters_to_gaql_string_non_empty_list_returns_condition_string():
+  filters = [
+      ['clicks', '>', '10'],
+      ['impressions', '>=', '100'],
+  ]
+  expected = 'metrics.clicks > 10 AND metrics.impressions >= 100'
+  assert main._gads_filters_to_gaql_string(filters) == expected
+
+
+def test_gads_filters_to_gaql_string_empty_list_returns_empty_string():
+  assert not main._gads_filters_to_gaql_string([])
+
+
+@mock.patch.object(main.discovery, 'build')
+@mock.patch.object(main.google.auth, 'default')
+def test_get_config_from_sheet_valid_sheet_returns_customer_configs(
+    mock_auth_default, mock_build
+):
+  mock_creds = mock.Mock()
+  mock_creds.universe_domain = 'googleapis.com'
+  mock_auth_default.return_value = (mock_creds, 'test_project')
+  mock_sheets_service = mock.Mock()
+  mock_build.return_value = mock_sheets_service
+
+  mock_spreadsheets = mock.Mock()
+  mock_sheets_service.spreadsheets.return_value = mock_spreadsheets
+
+  def values_get_side_effect(**kwargs):
+    """Mock side effect for spreadsheets.values.get."""
+    mock_execute = mock.Mock()
+    range_name = kwargs.get('range')
+    if range_name == 'google_ads_customer_ids':
+      mock_execute.execute.return_value = {
+          'values': [
+              ['123-456-7890', 'Enabled', '999-888-7777'],
+              ['111-222-3333', 'Disabled', '444-555-6666'],
+              ['723-928-2798', 'Disabled'],
+              ['356-029-6721', 'Enabled'],
+          ]
+      }
+    elif range_name == 'google_ads_filters':
+      mock_execute.execute.return_value = {'values': [['clicks', '>', '5']]}
+    elif range_name == 'google_ads_lookback_days':
+      mock_execute.execute.return_value = {'values': [['90']]}
+    elif range_name == 'configuration':
+      mock_execute.execute.return_value = {
+          'values': [['foo', 'bar'], ['baz', 'qux']]
+      }
+    return mock_execute
+
+  mock_spreadsheets.values.return_value.get.side_effect = values_get_side_effect
+
+  result = main._get_config_from_sheet('test_sheet_123')
+
+  assert len(result) == 2
+  assert result[0] == {
+      'sheet_id': 'test_sheet_123',
+      'customer_id': '1234567890',
+      'mcc_for_exclusions': '9998887777',
+      'lookback_days': 90,
+      'gads_filters': 'metrics.clicks > 5',
+      'settings': {'foo': 'bar', 'baz': 'qux'},
+  }
+  assert result[1] == {
+      'sheet_id': 'test_sheet_123',
+      'customer_id': '3560296721',
+      'mcc_for_exclusions': '',
+      'lookback_days': 90,
+      'gads_filters': 'metrics.clicks > 5',
+      'settings': {'foo': 'bar', 'baz': 'qux'},
+  }
+
+
+@mock.patch.object(main.discovery, 'build')
+@mock.patch.object(main.google.auth, 'default')
+def test_get_config_from_sheet_empty_lookback_days_defaults_to_1(
+    mock_auth_default, mock_build
+):
+  mock_creds = mock.Mock()
+  mock_creds.universe_domain = 'googleapis.com'
+  mock_auth_default.return_value = (mock_creds, 'test_project')
+  mock_sheets_service = mock.Mock()
+  mock_build.return_value = mock_sheets_service
+  mock_spreadsheets = mock.Mock()
+  mock_sheets_service.spreadsheets.return_value = mock_spreadsheets
+
+  def values_get_side_effect(**kwargs):
+    """Mock side effect for spreadsheets.values.get."""
+    mock_execute = mock.Mock()
+    range_name = kwargs.get('range')
+    if range_name == 'google_ads_customer_ids':
+      mock_execute.execute.return_value = {
+          'values': [['1234567890', 'Enabled', '9998887777']]
+      }
+    elif range_name == 'google_ads_lookback_days':
+      mock_execute.execute.return_value = {'values': []}
+    else:
+      mock_execute.execute.return_value = {'values': []}
+    return mock_execute
+
+  mock_spreadsheets.values.return_value.get.side_effect = values_get_side_effect
+
+  result = main._get_config_from_sheet('test_sheet_123')
+  assert len(result) == 1
+  assert result[0]['lookback_days'] == 1
+
+
+@mock.patch.object(main, 'publish_batch')
+@mock.patch.object(main, '_get_config_from_sheet')
+def test_run_valid_sheet_fetches_config_and_publishes_batch(
+    mock_get_config, mock_publish
+):
+  mock_get_config.return_value = [{'sheet_id': 's1'}]
+  main.run('test_sheet_123')
+  mock_get_config.assert_called_once_with('test_sheet_123')
+  mock_publish.assert_called_once()
+
+
+def test_main_http_valid_request_returns_200_success():
+  app = flask.Flask(__name__)
+  with app.test_request_context(
+      json={'sheet_id': 'test_sheet_123'},
+      method='POST',
+  ):
+    with mock.patch.object(main, 'run') as mock_run:
+      response = main.main(flask.request)
+      mock_run.assert_called_once_with('test_sheet_123')
+      assert response.status_code == 200
+      data = json.loads(response.get_data(as_text=True))
+      assert data['status'] == 'Success'
+
+
+def test_main_http_schema_validation_error_returns_400():
+  app = flask.Flask(__name__)
+  with app.test_request_context(
+      json={'invalid_key': 'foo'},
+      method='POST',
+  ):
+    response = main.main(flask.request)
+    assert response.status_code == 400
+    data = json.loads(response.get_data(as_text=True))
+    assert data['status'] == 'Failed'
+
+
+def test_main_http_empty_request_body_returns_400():
+  app = flask.Flask(__name__)
+  with app.test_request_context(
+      data='',
+      method='POST',
+      content_type='application/json',
+  ):
+    response = main.main(flask.request)
+    assert response.status_code == 400
+    data = json.loads(response.get_data(as_text=True))
+    assert data['status'] == 'Failed'
+
+
+def test_main_http_internal_server_error_returns_500():
+  app = flask.Flask(__name__)
+  with app.test_request_context(
+      json={'sheet_id': 'test_sheet_123'},
+      method='POST',
+  ):
+    with mock.patch.object(main, 'run', side_effect=RuntimeError('API error')):
+      response = main.main(flask.request)
+      assert response.status_code == 500
+      data = json.loads(response.get_data(as_text=True))
+      assert data['status'] == 'Failed'
+      assert 'API error' in data['message']

--- a/src/vet_common/__init__.py
+++ b/src/vet_common/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared utilities and common infrastructure for Video Exclusion Toolbox (VET) services."""

--- a/src/vet_common/ids.py
+++ b/src/vet_common/ids.py
@@ -1,0 +1,29 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ID sanitization utilities for Google Ads Customer and MCC IDs."""
+
+from typing import Any
+
+
+def sanitize_gads_id(raw_id: Any) -> str:
+  """Strips hyphens and whitespace from a Google Ads ID to return a clean numerical string.
+
+  Args:
+      raw_id: The ID string or integer from a spreadsheet or API response.
+
+  Returns:
+      A sanitized ID string without hyphens or leading/trailing whitespace.
+  """
+  return str(raw_id).replace('-', '').strip()

--- a/src/vet_common/logging.py
+++ b/src/vet_common/logging.py
@@ -1,0 +1,54 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Standardized Cloud Logging bootstrap for Video Exclusion Toolbox services."""
+
+import logging
+import os
+import sys
+
+from google.cloud import logging as cloud_logging
+
+
+def get_service_logger(
+    service_name_env: str = 'K_SERVICE',
+    default_name: str = 'failed_to_get_cloud_function_name',
+    log_level: int = logging.INFO,
+) -> logging.Logger:
+  """Initializes and returns a logger configured for Cloud Run or local testing.
+
+  Args:
+      service_name_env: Environment variable name storing the service name.
+      default_name: Fallback name if service_name_env is not present.
+      log_level: Logging level for the service logger.
+
+  Returns:
+      A configured standard Python Logger instance.
+  """
+  service_name = os.environ.get(service_name_env, default_name)
+  logger = logging.getLogger(service_name)
+
+  if os.getenv('IS_LOCAL_TEST', 'False') == 'True':
+    logging.basicConfig(level=log_level, stream=sys.stdout)
+  else:
+    logging_client = cloud_logging.Client()
+    logging_client.setup_logging(log_level=log_level)
+
+  # Suppress noisy default logging from third-party client libraries.
+  logging.getLogger('google_genai').setLevel(logging.WARNING)
+  logging.getLogger('httpx').setLevel(logging.WARNING)
+  logging.getLogger('google.ads.googleads.client').setLevel(logging.WARNING)
+
+  logger.setLevel(log_level)
+  return logger

--- a/src/vet_common/pubsub.py
+++ b/src/vet_common/pubsub.py
@@ -1,0 +1,90 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Asynchronous batch publishing helper for Google Cloud Pub/Sub."""
+
+from concurrent import futures
+import functools
+import json
+import logging
+from typing import Any, Optional
+
+from google.cloud import pubsub_v1
+
+
+def publish_batch(
+    project_id: str,
+    topic_id: str,
+    messages: list[dict[str, Any]],
+    logger: Optional[logging.Logger] = None,
+    max_messages: int = 100,
+) -> None:
+  """Publishes multiple messages to a Pub/Sub topic with batch settings.
+
+  Args:
+      project_id: The Google Cloud Project containing the Pub/Sub topic.
+      topic_id: The name of the topic to publish messages to.
+      messages: A list of message dictionary payloads to publish.
+      logger: Optional Logger instance to log publishing progress and errors.
+      max_messages: Maximum number of messages per batch.
+  """
+  if not logger:
+    logger = logging.getLogger(__name__)
+
+  batch_settings = pubsub_v1.types.BatchSettings(max_messages=max_messages)
+  publisher = pubsub_v1.PublisherClient(batch_settings)
+  topic_path = publisher.topic_path(project_id, topic_id)
+  publish_futures: list[futures.Future[str]] = []
+
+  def callback(
+      data: bytes,
+      current: int,
+      total: int,
+      topic_path_str: str,
+      future: futures.Future[str],
+  ) -> None:
+    if future.exception():
+      logger.info(
+          'Failed to publish %s to %s, exception:\n%s.',
+          data.decode('UTF-8'),
+          topic_path_str,
+          str(future.exception()),
+      )
+    else:
+      logger.info(
+          'Message %s (%d/%d) published to %s.',
+          data.decode('UTF-8'),
+          current,
+          total,
+          topic_path_str,
+      )
+
+  for current, data_item in enumerate(messages):
+    message_str = json.dumps(data_item)
+    data = message_str.encode('utf-8')
+    publish_future = publisher.publish(topic_path, data)
+    publish_future.add_done_callback(
+        functools.partial(
+            callback, data, current + 1, len(messages), topic_path
+        )
+    )
+    publish_futures.append(publish_future)
+
+  futures.wait(publish_futures, return_when=futures.ALL_COMPLETED)
+
+  logger.info(
+      'Finished publishing %d messages as a batch to %s.',
+      len(messages),
+      topic_path,
+  )

--- a/src/vet_common/tests/__init__.py
+++ b/src/vet_common/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test suite for the vet_common shared utility package."""

--- a/src/vet_common/tests/test_vet_common.py
+++ b/src/vet_common/tests/test_vet_common.py
@@ -1,0 +1,58 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for vet_common shared utilities."""
+
+from concurrent import futures
+import os
+from unittest import mock
+
+from google.cloud import pubsub_v1
+from vet_common.ids import sanitize_gads_id
+from vet_common.logging import get_service_logger
+from vet_common.pubsub import publish_batch
+
+
+def test_sanitize_gads_id():
+  """Test sanitizing Google Ads customer IDs."""
+  assert sanitize_gads_id('123-456-7890') == '1234567890'
+  assert sanitize_gads_id(1234567890) == '1234567890'
+  assert sanitize_gads_id('  123-456-7890  ') == '1234567890'
+
+
+def test_get_service_logger_local_test():
+  """Test logger configuration in local test environment."""
+  with mock.patch.dict(
+      os.environ, {'IS_LOCAL_TEST': 'True', 'K_SERVICE': 'test-service'}
+  ):
+    logger = get_service_logger()
+    assert logger.name == 'test-service'
+
+
+@mock.patch.object(pubsub_v1, 'PublisherClient', autospec=True)
+def test_publish_batch(mock_publisher_client_cls):
+  """Test publishing a batch of messages to Pub/Sub."""
+  mock_publisher = mock_publisher_client_cls.return_value
+  mock_publisher.topic_path.return_value = (
+      'projects/test-project/topics/test-topic'
+  )
+
+  mock_future = futures.Future()
+  mock_future.set_result('msg-id-123')
+  mock_publisher.publish.return_value = mock_future
+
+  messages = [{'foo': 'bar'}, {'baz': 123}]
+  publish_batch('test-project', 'test-topic', messages)
+
+  assert mock_publisher.publish.call_count == 2

--- a/terraform/data_archive_file.tf
+++ b/terraform/data_archive_file.tf
@@ -12,89 +12,119 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-data "archive_file" "google_ads_accounts" {
+data "archive_file" "gads_account_dispatcher" {
   type        = "zip"
-  output_path = ".temp/google_ads_accounts.zip"
-  source_dir  = "../src/google_ads_accounts/"
+  output_path = ".temp/gads_account_dispatcher.zip"
+  source {
+    content  = file("../src/google-ads-accounts-dispatcher/main.py")
+    filename = "main.py"
+  }
+  source {
+    content  = "${file("../src/common_requirements.txt")}\n${file("../src/google-ads-accounts-dispatcher/requirements.txt")}"
+    filename = "requirements.txt"
+  }
+  source {
+    content  = file("../src/vet_common/__init__.py")
+    filename = "vet_common/__init__.py"
+  }
+  source {
+    content  = file("../src/vet_common/logging.py")
+    filename = "vet_common/logging.py"
+  }
+  source {
+    content  = file("../src/vet_common/pubsub.py")
+    filename = "vet_common/pubsub.py"
+  }
+  source {
+    content  = file("../src/vet_common/ids.py")
+    filename = "vet_common/ids.py"
+  }
   depends_on = [resource.google_project_iam_member.storage_object_admin]
 }
-data "archive_file" "google_ads_exclusions" {
+data "archive_file" "google_ads_exclusions_fetcher" {
   type        = "zip"
-  output_path = ".temp/google_ads_exclusions.zip"
-  source_dir  = "../src/google_ads_exclusions/"
+  output_path = ".temp/google-ads-exclusions-fetcher.zip"
+  source {
+    content  = file("../src/google-ads-exclusions-fetcher/main.py")
+    filename = "main.py"
+  }
+  source {
+    content  = file("../src/google-ads-exclusions-fetcher/requirements.txt")
+    filename = "requirements.txt"
+  }
   depends_on = [resource.google_project_iam_member.storage_object_admin]
 }
 data "archive_file" "google_ads_excluder" {
   type        = "zip"
   output_path = ".temp/google_ads_excluder.zip"
   source_dir  = "../src/google_ads_excluder/"
-  depends_on = [resource.google_project_iam_member.storage_object_admin]
+  depends_on  = [resource.google_project_iam_member.storage_object_admin]
 }
 data "archive_file" "google_ads_report_video" {
   type        = "zip"
   output_path = ".temp/google_ads_report_video.zip"
   source_dir  = "../src/google_ads_report_video/"
-  depends_on = [resource.google_project_iam_member.storage_object_admin]
+  depends_on  = [resource.google_project_iam_member.storage_object_admin]
 }
 data "archive_file" "google_ads_report_channel" {
   type        = "zip"
   output_path = ".temp/google_ads_report_channel.zip"
   source_dir  = "../src/google_ads_report_channel/"
-  depends_on = [resource.google_project_iam_member.storage_object_admin]
+  depends_on  = [resource.google_project_iam_member.storage_object_admin]
 }
 data "archive_file" "youtube_channel" {
   type        = "zip"
   output_path = ".temp/youtube_channel.zip"
   source_dir  = "../src/youtube_channel/"
-  depends_on = [resource.google_project_iam_member.storage_object_admin]
+  depends_on  = [resource.google_project_iam_member.storage_object_admin]
 }
 data "archive_file" "youtube_video" {
   type        = "zip"
   output_path = ".temp/youtube_video.zip"
   source_dir  = "../src/youtube_video/"
-  depends_on = [resource.google_project_iam_member.storage_object_admin]
+  depends_on  = [resource.google_project_iam_member.storage_object_admin]
 }
 data "archive_file" "youtube_thumbnails_dispatch" {
   type        = "zip"
   output_path = ".temp/youtube_thumbnails_dispatch.zip"
   source_dir  = "../src/youtube_thumbnails_dispatch/"
-  depends_on = [resource.google_project_iam_member.storage_object_admin]
+  depends_on  = [resource.google_project_iam_member.storage_object_admin]
 }
 data "archive_file" "youtube_thumbnails_identify_objects" {
   type        = "zip"
   output_path = ".temp/youtube_thumbnails_identify_objects.zip"
   source_dir  = "../src/youtube_thumbnails_identify_objects/"
-  depends_on = [resource.google_project_iam_member.storage_object_admin]
+  depends_on  = [resource.google_project_iam_member.storage_object_admin]
 }
 data "archive_file" "youtube_thumbnails_generate_cropouts" {
   type        = "zip"
   output_path = ".temp/youtube_thumbnails_generate_cropouts.zip"
   source_dir  = "../src/youtube_thumbnails_generate_cropouts/"
-  depends_on = [resource.google_project_iam_member.storage_object_admin]
+  depends_on  = [resource.google_project_iam_member.storage_object_admin]
 }
 
 data "archive_file" "youtube_thumbnails_evaluate_age_dispatcher" {
   type        = "zip"
   output_path = ".temp/youtube_thumbnails_evaluate_age_dispatcher.zip"
   source {
-    content = file("../src/youtube_thumbnails_evaluate_age_dispatcher/main.py")
+    content  = file("../src/youtube_thumbnails_evaluate_age_dispatcher/main.py")
     filename = "main.py"
   }
   source {
-    content = file("../src/youtube_thumbnails_evaluate_age_dispatcher/requirements.txt")
+    content  = file("../src/youtube_thumbnails_evaluate_age_dispatcher/requirements.txt")
     filename = "requirements.txt"
   }
-  depends_on  = [resource.google_project_iam_member.storage_object_admin]
+  depends_on = [resource.google_project_iam_member.storage_object_admin]
 }
 data "archive_file" "youtube_thumbnails_evaluate_age_processor" {
   type        = "zip"
   output_path = ".temp/youtube_thumbnails_evaluate_age_processor.zip"
   source {
-    content = file("../src/youtube_thumbnails_evaluate_age_processor/main.py")
+    content  = file("../src/youtube_thumbnails_evaluate_age_processor/main.py")
     filename = "main.py"
   }
   source {
-    content = file("../src/youtube_thumbnails_evaluate_age_processor/requirements.txt")
+    content  = file("../src/youtube_thumbnails_evaluate_age_processor/requirements.txt")
     filename = "requirements.txt"
   }
   depends_on = [resource.google_project_iam_member.storage_object_admin]

--- a/terraform/resource_google_bigquery_table.tf
+++ b/terraform/resource_google_bigquery_table.tf
@@ -66,7 +66,7 @@ resource "google_bigquery_table" "youtube_video" {
   schema              = file("../bq_schemas/youtube_video.json")
 }
 
-resource "google_bigquery_table" "youtube_thubmnails" {
+resource "google_bigquery_table" "youtube_thumbnails" {
   project             = "${var.project_id}"
   dataset_id          = google_bigquery_dataset.video_exclusion_toolbox.dataset_id
   table_id            = "YouTubeThumbnailsWithAnnotations"
@@ -75,7 +75,7 @@ resource "google_bigquery_table" "youtube_thubmnails" {
   schema              = file("../bq_schemas/youtube_thumbnail_annotation.json")
 }
 
-resource "google_bigquery_table" "youtube_thubmnail_cropouts" {
+resource "google_bigquery_table" "youtube_thumbnail_cropouts" {
   project             = "${var.project_id}"
   dataset_id          = google_bigquery_dataset.video_exclusion_toolbox.dataset_id
   table_id            = "YouTubeThumbnailCropouts"
@@ -313,7 +313,7 @@ resource "google_bigquery_table" "videos_to_exclude" {
     google_bigquery_table.videos_with_matched_keywords
   ]
   view {
-    query = <<-EOT
+    query          = <<-EOT
       SELECT
         DISTINCT video_id, video_url, title, description, tags,
         CONCAT(
@@ -340,7 +340,7 @@ resource "google_bigquery_table" "channels_to_exclude" {
     google_bigquery_table.channels_with_matched_keywords
   ]
   view {
-    query = <<-EOT
+    query          = <<-EOT
       SELECT
         DISTINCT channel_id, channel_url, title,
         CONCAT('Found: [', title_match, '] in title') as reason
@@ -360,7 +360,7 @@ resource "google_bigquery_table" "video_keyword_statistics" {
     google_bigquery_table.videos_with_matched_keywords
   ]
   view {
-    query = <<-EOT
+    query          = <<-EOT
       WITH exploded_table AS (
         SELECT
           SPLIT(title_match, ',') AS title_words,
@@ -412,7 +412,7 @@ resource "google_bigquery_table" "channel_keyword_statistics" {
     google_bigquery_dataset.video_exclusion_toolbox,
   ]
   view {
-    query = <<-EOT
+    query          = <<-EOT
       WITH exploded_table AS (
         SELECT
           SPLIT(title_match, ',') AS title_words

--- a/terraform/resource_google_cloud_scheduler_job.tf
+++ b/terraform/resource_google_cloud_scheduler_job.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 locals {
-  scheduler_body = <<EOF
+  scheduler_body                        = <<EOF
     {
         "sheet_id": "${var.config_sheet_id}"
     }
@@ -26,9 +26,9 @@ locals {
     EOF
 }
 
-resource "google_cloud_scheduler_job" "video_exclusion_toolbox_run_process" {
-  name             = "video_exclusion_toolbox"
-  description      = "Run the Video Exclusion Toolbox"
+resource "google_cloud_scheduler_job" "gads_dispatch_accounts" {
+  name             = "vet-gads-dispatch-accounts-job"
+  description      = "Dispatches Google Ads accounts for processing."
   schedule         = "0 * * * *"
   time_zone        = "Etc/UTC"
   attempt_deadline = "320s"
@@ -36,12 +36,13 @@ resource "google_cloud_scheduler_job" "video_exclusion_toolbox_run_process" {
 
   http_target {
     http_method = "POST"
-    uri         = google_cloudfunctions_function.google_ads_accounts.https_trigger_url
+    uri         = google_cloudfunctions2_function.gads_account_dispatcher.service_config[0].uri
     body        = base64encode(local.scheduler_body)
     headers = {
       "Content-Type" = "application/json"
     }
     oidc_token {
+      audience              = "${google_cloudfunctions2_function.gads_account_dispatcher.service_config[0].uri}/"
       service_account_email = google_service_account.video_exclusion_toolbox.email
     }
   }
@@ -60,8 +61,7 @@ resource "google_cloud_scheduler_job" "vet_evaluate_thumbnail_age" {
     uri         = google_cloudfunctions2_function.youtube_thumbnails_evaluate_age_dispatcher.service_config[0].uri
     body        = base64encode(local.evaluate_thumbnail_age_scheduler_body)
     headers = {
-      "Content-Type" = "application/json",
-      "User-Agent" = "Google-Cloud-Scheduler"
+      "Content-Type" = "application/json"
     }
     oidc_token {
       audience              = "${google_cloudfunctions2_function.youtube_thumbnails_evaluate_age_dispatcher.service_config[0].uri}/"

--- a/terraform/resource_google_cloudfunctions2_function.tf
+++ b/terraform/resource_google_cloudfunctions2_function.tf
@@ -12,28 +12,123 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-resource "google_cloudfunctions2_function" "youtube_thumbnails_evaluate_age_dispatcher" {
-  location              = var.region
-  name                  = "vet-thumbnail-age-evaluation-dispatcher"
-  description           = "Dispatch videos for thumbnail age evaluation."
+resource "google_cloudfunctions2_function" "gads_account_dispatcher" {
+  location    = var.region
+  name        = "vet-gads-account-dispatcher"
+  description = "Dispatch Google Ads accounts for processing."
 
   service_config {
-    max_instance_count  = 2
-    min_instance_count  = 1
-    available_memory    = "1Gi"
-    timeout_seconds     = 600
-    available_cpu       = "1"
+    max_instance_count               = 2
+    min_instance_count               = 1
+    available_memory                 = "1Gi"
+    timeout_seconds                  = 600
+    available_cpu                    = "1"
     max_instance_request_concurrency = 1
     environment_variables = {
-        GOOGLE_CLOUD_PROJECT                = var.project_id
-        VET_THUMBNAIL_AGE_EVALUATION_TOPIC  = google_pubsub_topic.youtube_thumbnails_to_evaluate_age.name
-        VET_BIGQUERY_SOURCE_DATASET         = google_bigquery_dataset.video_exclusion_toolbox.dataset_id
-        VET_BIGQUERY_TARGET_DATASET         = google_bigquery_dataset.video_exclusion_toolbox.dataset_id
-        VET_BIGQUERY_SOURCE_TABLE           = google_bigquery_table.youtube_video.table_id
-        VET_BIGQUERY_TARGET_TABLE           = google_bigquery_table.youtube_thumbnail_age_evaluation.table_id
+      GOOGLE_CLOUD_PROJECT         = var.project_id
+      VET_GOOGLE_ADS_ACCOUNT_TOPIC = google_pubsub_topic.gads_account.name
     }
-    ingress_settings      = "ALLOW_INTERNAL_ONLY"
+    ingress_settings               = "ALLOW_INTERNAL_ONLY"
+    service_account_email          = google_service_account.video_exclusion_toolbox.email
+    all_traffic_on_latest_revision = true
+  }
+
+  build_config {
+    runtime     = "python312"
+    entry_point = "main"
+    source {
+      storage_source {
+        bucket = google_storage_bucket.source_archive.name
+        object = google_storage_bucket_object.gads_account_dispatcher.name
+      }
+    }
+  }
+
+  depends_on = [
+    resource.time_sleep.wait_60_seconds_after_role_assignment,
+    resource.google_storage_bucket_object.gads_account_dispatcher
+  ]
+}
+
+resource "google_cloudfunctions2_function" "google_ads_exclusions_fetcher" {
+  location    = var.region
+  name        = "vet-google-ads-exclusions-fetcher"
+  description = "Fetches exclusion lists from Google Ads accounts."
+
+  service_config {
+    max_instance_count               = 10
+    min_instance_count               = 1
+    available_memory                 = "1Gi"
+    timeout_seconds                  = 540
+    available_cpu                    = "1"
+    max_instance_request_concurrency = 1
+    environment_variables = {
+      GOOGLE_CLOUD_PROJECT         = var.project_id
+      GOOGLE_ADS_CLIENT_VERSION    = var.google_ads_client_version
+      GOOGLE_ADS_LOGIN_CUSTOMER_ID = var.google_ads_login_customer_id
+      GOOGLE_ADS_USE_PROTO_PLUS    = "false"
+      VET_BIGQUERY_TARGET_DATASET  = google_bigquery_dataset.video_exclusion_toolbox.dataset_id
+      VET_BIGQUERY_TARGET_TABLE    = google_bigquery_table.google_ads_exclusions.table_id
+    }
+    secret_environment_variables {
+      key        = "GOOGLE_ADS_DEVELOPER_TOKEN"
+      project_id = var.project_id
+      secret     = google_secret_manager_secret.developer_token.secret_id
+      version    = "latest"
+    }
+    ingress_settings               = "ALLOW_INTERNAL_ONLY"
+    service_account_email          = google_service_account.video_exclusion_toolbox.email
+    all_traffic_on_latest_revision = true
+  }
+
+  build_config {
+    runtime     = "python312"
+    entry_point = "main"
+    source {
+      storage_source {
+        bucket = google_storage_bucket.source_archive.name
+        object = google_storage_bucket_object.google_ads_exclusions_fetcher.name
+      }
+    }
+  }
+
+  event_trigger {
+    trigger_region        = var.region
+    event_type            = "google.cloud.pubsub.topic.v1.messagePublished"
+    pubsub_topic          = google_pubsub_topic.gads_account.id
+    retry_policy          = "RETRY_POLICY_RETRY"
     service_account_email = google_service_account.video_exclusion_toolbox.email
+  }
+
+  depends_on = [
+    resource.time_sleep.wait_60_seconds_after_role_assignment,
+    resource.google_storage_bucket_object.google_ads_exclusions_fetcher,
+    resource.google_secret_manager_secret_version.developer_token
+  ]
+}
+
+resource "google_cloudfunctions2_function" "youtube_thumbnails_evaluate_age_dispatcher" {
+  location    = var.region
+  name        = "vet-thumbnail-age-evaluation-dispatcher"
+  description = "Dispatch videos for thumbnail age evaluation."
+
+  service_config {
+    max_instance_count               = 2
+    min_instance_count               = 1
+    available_memory                 = "1Gi"
+    timeout_seconds                  = 600
+    available_cpu                    = "1"
+    max_instance_request_concurrency = 1
+    environment_variables = {
+      GOOGLE_CLOUD_PROJECT               = var.project_id
+      VET_THUMBNAIL_AGE_EVALUATION_TOPIC = google_pubsub_topic.youtube_thumbnails_to_evaluate_age.name
+      VET_BIGQUERY_SOURCE_DATASET        = google_bigquery_dataset.video_exclusion_toolbox.dataset_id
+      VET_BIGQUERY_TARGET_DATASET        = google_bigquery_dataset.video_exclusion_toolbox.dataset_id
+      VET_BIGQUERY_SOURCE_TABLE          = google_bigquery_table.youtube_video.table_id
+      VET_BIGQUERY_TARGET_TABLE          = google_bigquery_table.youtube_thumbnail_age_evaluation.table_id
+    }
+    ingress_settings               = "ALLOW_INTERNAL_ONLY"
+    service_account_email          = google_service_account.video_exclusion_toolbox.email
     all_traffic_on_latest_revision = true
   }
 
@@ -46,7 +141,6 @@ resource "google_cloudfunctions2_function" "youtube_thumbnails_evaluate_age_disp
         object = google_storage_bucket_object.youtube_thumbnails_evaluate_age_dispatcher.name
       }
     }
-    service_account = google_service_account.video_exclusion_toolbox.id
   }
 
   depends_on = [
@@ -61,29 +155,29 @@ resource "google_cloudfunctions2_function" "youtube_thumbnails_evaluate_age_proc
   description = "Process videos for thumbnail age evaluation."
 
   service_config {
-    max_instance_count  = 200
-    min_instance_count  = 0
-    available_memory    = "1Gi"
-    timeout_seconds     = 540
-    available_cpu       = "1"
+    max_instance_count               = 200
+    min_instance_count               = 0
+    available_memory                 = "1Gi"
+    timeout_seconds                  = 540
+    available_cpu                    = "1"
     max_instance_request_concurrency = 1
     environment_variables = {
-        GOOGLE_CLOUD_PROJECT        = var.project_id
-        VET_BIGQUERY_TARGET_DATASET = google_bigquery_dataset.video_exclusion_toolbox.dataset_id
-        VET_BIGQUERY_TARGET_TABLE   = google_bigquery_table.youtube_thumbnail_age_evaluation.table_id
-        VET_GEMINI_LOCATION         = var.age_evaluation_gemini_location
-        VET_GEMINI_MODEL            = var.age_evaluation_gemini_model
+      GOOGLE_CLOUD_PROJECT        = var.project_id
+      VET_BIGQUERY_TARGET_DATASET = google_bigquery_dataset.video_exclusion_toolbox.dataset_id
+      VET_BIGQUERY_TARGET_TABLE   = google_bigquery_table.youtube_thumbnail_age_evaluation.table_id
+      VET_GEMINI_LOCATION         = var.age_evaluation_gemini_location
+      VET_GEMINI_MODEL            = var.age_evaluation_gemini_model
     }
-    ingress_settings      = "ALLOW_INTERNAL_ONLY"
-    service_account_email = google_service_account.video_exclusion_toolbox.email
+    ingress_settings               = "ALLOW_INTERNAL_ONLY"
+    service_account_email          = google_service_account.video_exclusion_toolbox.email
     all_traffic_on_latest_revision = true
   }
 
   event_trigger {
-    trigger_region  = var.region
-    event_type      = "google.cloud.pubsub.topic.v1.messagePublished"
-    pubsub_topic    = google_pubsub_topic.youtube_thumbnails_to_evaluate_age.id
-    retry_policy    = "RETRY_POLICY_RETRY"
+    trigger_region        = var.region
+    event_type            = "google.cloud.pubsub.topic.v1.messagePublished"
+    pubsub_topic          = google_pubsub_topic.youtube_thumbnails_to_evaluate_age.id
+    retry_policy          = "RETRY_POLICY_RETRY"
     service_account_email = google_service_account.video_exclusion_toolbox.email
   }
 
@@ -96,7 +190,6 @@ resource "google_cloudfunctions2_function" "youtube_thumbnails_evaluate_age_proc
         object = google_storage_bucket_object.youtube_thumbnails_evaluate_age_processor.name
       }
     }
-    service_account = google_service_account.video_exclusion_toolbox.id
   }
 
   depends_on = [

--- a/terraform/resource_google_cloudfunctions_function.tf
+++ b/terraform/resource_google_cloudfunctions_function.tf
@@ -12,84 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-resource "google_cloudfunctions_function" "google_ads_accounts" {
-  region                = var.region
-  name                  = "vid-excl-google_ads_accounts"
-  description           = "Identify which reports to run the Google Ads report for."
-  runtime               = "python311"
-  source_archive_bucket = google_storage_bucket.source_archive.name
-  source_archive_object = google_storage_bucket_object.google_ads_accounts.name
-  service_account_email = google_service_account.video_exclusion_toolbox.email
-  build_service_account = "projects/${var.project_id}/serviceAccounts/${google_service_account.video_exclusion_toolbox.email}"
-  timeout               = 540
-  available_memory_mb   = 1024
-  entry_point           = "main"
-  trigger_http          = true
-  depends_on = [
-    resource.time_sleep.wait_60_seconds_after_role_assignment,
-    resource.google_storage_bucket_object.google_ads_accounts
-  ]
-
-  environment_variables = {
-    GOOGLE_CLOUD_PROJECT              = var.project_id
-    VID_EXCL_ADS_ACCOUNT_PUBSUB_TOPIC = google_pubsub_topic.google_ads_account.name
-  }
-}
-
-
-resource "google_cloudfunctions_function" "google_ads_exclusions" {
-  region                = var.region
-  name                  = "vid-excl-google_ads_exclusions"
-  description           = "Retrieve all the excluded videos and channels for a given account and store them in BigQuery."
-  runtime               = "python311"
-  source_archive_bucket = google_storage_bucket.source_archive.name
-  source_archive_object = google_storage_bucket_object.google_ads_exclusions.name
-  service_account_email = google_service_account.video_exclusion_toolbox.email
-  build_service_account = "projects/${var.project_id}/serviceAccounts/${google_service_account.video_exclusion_toolbox.email}"
-  timeout               = 540
-  available_memory_mb   = 4096
-  entry_point           = "main"
-  depends_on = [
-    resource.time_sleep.wait_60_seconds_after_role_assignment,
-    resource.google_storage_bucket_object.google_ads_exclusions
-  ]
-
-  event_trigger {
-    event_type = "providers/cloud.pubsub/eventTypes/topic.publish"
-    resource   = google_pubsub_topic.google_ads_account.name
-  }
-
-  environment_variables = {
-    GOOGLE_ADS_USE_PROTO_PLUS    = false
-    GOOGLE_ADS_LOGIN_CUSTOMER_ID = var.google_ads_login_customer_id
-    GOOGLE_CLOUD_PROJECT         = var.project_id
-    VID_EXCL_BIGQUERY_DATASET    = google_bigquery_dataset.video_exclusion_toolbox.dataset_id
-  }
-
-  secret_environment_variables {
-    key     = "GOOGLE_ADS_REFRESH_TOKEN"
-    secret  = google_secret_manager_secret.oauth_refresh_token.secret_id
-    version = "latest"
-  }
-  secret_environment_variables {
-    key     = "GOOGLE_ADS_CLIENT_ID"
-    secret  = google_secret_manager_secret.client_id.secret_id
-    version = "latest"
-  }
-  secret_environment_variables {
-    key     = "GOOGLE_ADS_CLIENT_SECRET"
-    secret  = google_secret_manager_secret.client_secret.secret_id
-    version = "latest"
-  }
-  secret_environment_variables {
-    key     = "GOOGLE_ADS_DEVELOPER_TOKEN"
-    secret  = google_secret_manager_secret.developer_token.secret_id
-    version = "latest"
-  }
-
-}
-
-
 resource "google_cloudfunctions_function" "google_ads_report_video" {
   region                = var.region
   name                  = "vid-excl-google_ads_report_video"
@@ -109,7 +31,7 @@ resource "google_cloudfunctions_function" "google_ads_report_video" {
 
   event_trigger {
     event_type = "providers/cloud.pubsub/eventTypes/topic.publish"
-    resource   = google_pubsub_topic.google_ads_account.name
+    resource   = google_pubsub_topic.gads_account.name
   }
 
   environment_variables = {
@@ -163,7 +85,7 @@ resource "google_cloudfunctions_function" "google_ads_report_channel" {
 
   event_trigger {
     event_type = "providers/cloud.pubsub/eventTypes/topic.publish"
-    resource   = google_pubsub_topic.google_ads_account.name
+    resource   = google_pubsub_topic.gads_account.name
   }
 
   environment_variables = {

--- a/terraform/resource_google_project_iam_member.tf
+++ b/terraform/resource_google_project_iam_member.tf
@@ -13,56 +13,50 @@
 # limitations under the License.
 
 resource "google_project_iam_member" "cloud_functions_invoker" {
-  project = var.project_id
-  role    = "roles/cloudfunctions.invoker"
-  member  = "serviceAccount:${google_service_account.video_exclusion_toolbox.email}"
+  project    = var.project_id
+  role       = "roles/cloudfunctions.invoker"
+  member     = "serviceAccount:${google_service_account.video_exclusion_toolbox.email}"
   depends_on = [resource.google_service_account.video_exclusion_toolbox]
 }
 resource "google_project_iam_member" "bigquery_job_user" {
-  project = var.project_id
-  role    = "roles/bigquery.jobUser"
-  member  = "serviceAccount:${google_service_account.video_exclusion_toolbox.email}"
+  project    = var.project_id
+  role       = "roles/bigquery.jobUser"
+  member     = "serviceAccount:${google_service_account.video_exclusion_toolbox.email}"
   depends_on = [resource.google_service_account.video_exclusion_toolbox]
 }
 resource "google_project_iam_member" "bigquery_data_owner" {
-  project = var.project_id
-  role    = "roles/bigquery.dataOwner"
-  member  = "serviceAccount:${google_service_account.video_exclusion_toolbox.email}"
+  project    = var.project_id
+  role       = "roles/bigquery.dataOwner"
+  member     = "serviceAccount:${google_service_account.video_exclusion_toolbox.email}"
   depends_on = [resource.google_service_account.video_exclusion_toolbox]
 }
 resource "google_project_iam_member" "pubsub_publisher" {
-  project = var.project_id
-  role    = "roles/pubsub.publisher"
-  member  = "serviceAccount:${google_service_account.video_exclusion_toolbox.email}"
+  project    = var.project_id
+  role       = "roles/pubsub.publisher"
+  member     = "serviceAccount:${google_service_account.video_exclusion_toolbox.email}"
   depends_on = [resource.google_service_account.video_exclusion_toolbox]
 }
 resource "google_project_iam_member" "storage_object_admin" {
-  project = var.project_id
-  role    = "roles/storage.objectAdmin"
-  member  = "serviceAccount:${google_service_account.video_exclusion_toolbox.email}"
+  project    = var.project_id
+  role       = "roles/storage.objectAdmin"
+  member     = "serviceAccount:${google_service_account.video_exclusion_toolbox.email}"
   depends_on = [resource.google_service_account.video_exclusion_toolbox]
 }
 resource "google_project_iam_member" "secret_accessor" {
-  project = var.project_id
-  role    = "roles/secretmanager.secretAccessor"
-  member  = "serviceAccount:${google_service_account.video_exclusion_toolbox.email}"
-  depends_on = [resource.google_service_account.video_exclusion_toolbox]
-}
-resource "google_project_iam_member" "cloudbuild_builds_builder" {
-  project = var.project_id
-  role    = "roles/cloudbuild.builds.builder"
-  member  = "serviceAccount:${google_service_account.video_exclusion_toolbox.email}"
+  project    = var.project_id
+  role       = "roles/secretmanager.secretAccessor"
+  member     = "serviceAccount:${google_service_account.video_exclusion_toolbox.email}"
   depends_on = [resource.google_service_account.video_exclusion_toolbox]
 }
 resource "google_project_iam_member" "cloudbuild_cloud_run_invoker" {
-  project = var.project_id
-  role    = "roles/run.invoker"
-  member  = "serviceAccount:${google_service_account.video_exclusion_toolbox.email}"
+  project    = var.project_id
+  role       = "roles/run.invoker"
+  member     = "serviceAccount:${google_service_account.video_exclusion_toolbox.email}"
   depends_on = [resource.google_service_account.video_exclusion_toolbox]
 }
 resource "google_project_iam_member" "cloudbuild_vertex_ai_user" {
-  project = var.project_id
-  role    = "roles/aiplatform.user"
-  member  = "serviceAccount:${google_service_account.video_exclusion_toolbox.email}"
+  project    = var.project_id
+  role       = "roles/aiplatform.user"
+  member     = "serviceAccount:${google_service_account.video_exclusion_toolbox.email}"
   depends_on = [resource.google_service_account.video_exclusion_toolbox]
 }

--- a/terraform/resource_google_pubsub_topic.tf
+++ b/terraform/resource_google_pubsub_topic.tf
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-resource "google_pubsub_topic" "google_ads_account" {
-  name                       = "vid-excl-google-ads-account"
+resource "google_pubsub_topic" "gads_account" {
+  name                       = "vet-gads-account-queue"
   message_retention_duration = "604800s"
 }
 

--- a/terraform/resource_google_storage_bucket_object.tf
+++ b/terraform/resource_google_storage_bucket_object.tf
@@ -13,109 +13,109 @@
 # limitations under the License.
 
 ######################## Source Code Archive Objects ###########################
-resource "google_storage_bucket_object" "google_ads_accounts" {
-  name       = "google_ads_accounts_${data.archive_file.google_ads_accounts.output_md5}.zip"
-  bucket     = google_storage_bucket.source_archive.name
-  source     = data.archive_file.google_ads_accounts.output_path
+resource "google_storage_bucket_object" "gads_account_dispatcher" {
+  name   = "gads-account-dispatcher-${data.archive_file.gads_account_dispatcher.output_md5}.zip"
+  bucket = google_storage_bucket.source_archive.name
+  source = data.archive_file.gads_account_dispatcher.output_path
   depends_on = [
-    data.archive_file.google_ads_accounts,
+    data.archive_file.gads_account_dispatcher,
     resource.google_storage_bucket.source_archive
   ]
 }
-resource "google_storage_bucket_object" "google_ads_exclusions" {
-  name       = "google_ads_exclusions_${data.archive_file.google_ads_exclusions.output_md5}.zip"
-  bucket     = google_storage_bucket.source_archive.name
-  source     = data.archive_file.google_ads_exclusions.output_path
+resource "google_storage_bucket_object" "google_ads_exclusions_fetcher" {
+  name   = "google-ads-exclusions-fetcher-${data.archive_file.google_ads_exclusions_fetcher.output_md5}.zip"
+  bucket = google_storage_bucket.source_archive.name
+  source = data.archive_file.google_ads_exclusions_fetcher.output_path
   depends_on = [
-    data.archive_file.google_ads_exclusions,
+    data.archive_file.google_ads_exclusions_fetcher,
     resource.google_storage_bucket.source_archive
   ]
 }
 resource "google_storage_bucket_object" "google_ads_excluder" {
-  name       = "google_ads_excluder_${data.archive_file.google_ads_excluder.output_md5}.zip"
-  bucket     = google_storage_bucket.source_archive.name
-  source     = data.archive_file.google_ads_excluder.output_path
+  name   = "google_ads_excluder_${data.archive_file.google_ads_excluder.output_md5}.zip"
+  bucket = google_storage_bucket.source_archive.name
+  source = data.archive_file.google_ads_excluder.output_path
   depends_on = [
     data.archive_file.google_ads_excluder,
     resource.google_storage_bucket.source_archive
   ]
 }
 resource "google_storage_bucket_object" "google_ads_report_video" {
-  name       = "google_ads_report_video${data.archive_file.google_ads_report_video.output_md5}.zip"
-  bucket     = google_storage_bucket.source_archive.name
-  source     = data.archive_file.google_ads_report_video.output_path
+  name   = "google_ads_report_video${data.archive_file.google_ads_report_video.output_md5}.zip"
+  bucket = google_storage_bucket.source_archive.name
+  source = data.archive_file.google_ads_report_video.output_path
   depends_on = [
     data.archive_file.google_ads_report_video,
     resource.google_storage_bucket.source_archive
   ]
 }
 resource "google_storage_bucket_object" "google_ads_report_channel" {
-  name       = "google_ads_report_channel${data.archive_file.google_ads_report_channel.output_md5}.zip"
-  bucket     = google_storage_bucket.source_archive.name
-  source     = data.archive_file.google_ads_report_channel.output_path
+  name   = "google_ads_report_channel${data.archive_file.google_ads_report_channel.output_md5}.zip"
+  bucket = google_storage_bucket.source_archive.name
+  source = data.archive_file.google_ads_report_channel.output_path
   depends_on = [
     data.archive_file.google_ads_report_channel,
     resource.google_storage_bucket.source_archive
   ]
 }
 resource "google_storage_bucket_object" "youtube_channel" {
-  name       = "youtube_channel_${data.archive_file.youtube_channel.output_md5}.zip"
-  bucket     = google_storage_bucket.source_archive.name
-  source     = data.archive_file.youtube_channel.output_path
+  name   = "youtube_channel_${data.archive_file.youtube_channel.output_md5}.zip"
+  bucket = google_storage_bucket.source_archive.name
+  source = data.archive_file.youtube_channel.output_path
   depends_on = [
     data.archive_file.youtube_channel,
     resource.google_storage_bucket.source_archive
   ]
 }
 resource "google_storage_bucket_object" "youtube_video" {
-  name       = "youtube_video_${data.archive_file.youtube_video.output_md5}.zip"
-  bucket     = google_storage_bucket.source_archive.name
-  source     = data.archive_file.youtube_video.output_path
+  name   = "youtube_video_${data.archive_file.youtube_video.output_md5}.zip"
+  bucket = google_storage_bucket.source_archive.name
+  source = data.archive_file.youtube_video.output_path
   depends_on = [
     data.archive_file.youtube_video,
     resource.google_storage_bucket.source_archive
   ]
 }
 resource "google_storage_bucket_object" "youtube_thumbnails_dispatch" {
-  name       = "youtube_thumbnails_dispatch_${data.archive_file.youtube_thumbnails_dispatch.output_md5}.zip"
-  bucket     = google_storage_bucket.source_archive.name
-  source     = data.archive_file.youtube_thumbnails_dispatch.output_path
+  name   = "youtube_thumbnails_dispatch_${data.archive_file.youtube_thumbnails_dispatch.output_md5}.zip"
+  bucket = google_storage_bucket.source_archive.name
+  source = data.archive_file.youtube_thumbnails_dispatch.output_path
   depends_on = [
     data.archive_file.youtube_thumbnails_dispatch,
     resource.google_storage_bucket.source_archive
   ]
 }
 resource "google_storage_bucket_object" "youtube_thumbnails_identify_objects" {
-  name       = "youtube_thumbnails_process_${data.archive_file.youtube_thumbnails_identify_objects.output_md5}.zip"
-  bucket     = google_storage_bucket.source_archive.name
-  source     = data.archive_file.youtube_thumbnails_identify_objects.output_path
+  name   = "youtube_thumbnails_process_${data.archive_file.youtube_thumbnails_identify_objects.output_md5}.zip"
+  bucket = google_storage_bucket.source_archive.name
+  source = data.archive_file.youtube_thumbnails_identify_objects.output_path
   depends_on = [
     data.archive_file.youtube_thumbnails_identify_objects,
     resource.google_storage_bucket.source_archive
   ]
 }
 resource "google_storage_bucket_object" "youtube_thumbnails_generate_cropouts" {
-  name       = "youtube_thumbnails_generate_cropouts_${data.archive_file.youtube_thumbnails_generate_cropouts.output_md5}.zip"
-  bucket     = google_storage_bucket.source_archive.name
-  source     = data.archive_file.youtube_thumbnails_generate_cropouts.output_path
+  name   = "youtube_thumbnails_generate_cropouts_${data.archive_file.youtube_thumbnails_generate_cropouts.output_md5}.zip"
+  bucket = google_storage_bucket.source_archive.name
+  source = data.archive_file.youtube_thumbnails_generate_cropouts.output_path
   depends_on = [
     data.archive_file.youtube_thumbnails_generate_cropouts,
     resource.google_storage_bucket.source_archive
   ]
 }
 resource "google_storage_bucket_object" "youtube_thumbnails_evaluate_age_dispatcher" {
-  name       = "youtube_thumbnails_evaluate_age_dispatcher_${data.archive_file.youtube_thumbnails_evaluate_age_dispatcher.output_md5}.zip"
-  bucket     = google_storage_bucket.source_archive.name
-  source     = data.archive_file.youtube_thumbnails_evaluate_age_dispatcher.output_path
+  name   = "youtube_thumbnails_evaluate_age_dispatcher_${data.archive_file.youtube_thumbnails_evaluate_age_dispatcher.output_md5}.zip"
+  bucket = google_storage_bucket.source_archive.name
+  source = data.archive_file.youtube_thumbnails_evaluate_age_dispatcher.output_path
   depends_on = [
     data.archive_file.youtube_thumbnails_evaluate_age_dispatcher,
     resource.google_storage_bucket.source_archive
   ]
 }
 resource "google_storage_bucket_object" "youtube_thumbnails_evaluate_age_processor" {
-  name       = "youtube_thumbnails_evaluate_age_processor_${data.archive_file.youtube_thumbnails_evaluate_age_processor.output_md5}.zip"
-  bucket     = google_storage_bucket.source_archive.name
-  source     = data.archive_file.youtube_thumbnails_evaluate_age_processor.output_path
+  name   = "youtube_thumbnails_evaluate_age_processor_${data.archive_file.youtube_thumbnails_evaluate_age_processor.output_md5}.zip"
+  bucket = google_storage_bucket.source_archive.name
+  source = data.archive_file.youtube_thumbnails_evaluate_age_processor.output_path
   depends_on = [
     data.archive_file.youtube_thumbnails_evaluate_age_processor,
     resource.google_storage_bucket.source_archive
@@ -124,8 +124,8 @@ resource "google_storage_bucket_object" "youtube_thumbnails_evaluate_age_process
 
 ########################## Auxiliary Bucket Objects ############################
 resource "google_storage_bucket_object" "categories_lookup" {
-  name          = "categories_lookup.csv"
-  bucket        = google_storage_bucket.categories_lookup.name
-  source        = "../src/categories_lookup.csv"
-  content_type  = "text/plain"
+  name         = "categories_lookup.csv"
+  bucket       = google_storage_bucket.categories_lookup.name
+  source       = "../src/categories_lookup.csv"
+  content_type = "text/plain"
 }

--- a/terraform/resource_time_sleep.tf
+++ b/terraform/resource_time_sleep.tf
@@ -6,7 +6,6 @@ resource "time_sleep" "wait_60_seconds_after_role_assignment" {
     resource.google_project_iam_member.bigquery_data_owner,
     resource.google_project_iam_member.pubsub_publisher,
     resource.google_project_iam_member.storage_object_admin,
-    resource.google_project_iam_member.secret_accessor,
-    resource.google_project_iam_member.cloudbuild_builds_builder
+    resource.google_project_iam_member.secret_accessor
   ]
 }


### PR DESCRIPTION
… test suite

- Refactor accounts dispatcher to Python 3.12 / Gen 2 Cloud Run Service (@functions_framework.http)
- Add customer and MCC ID sanitization and safe lookback_days / Sheets column unpacking
- Add centralized vet_common logging and Pub/Sub batch publishing utilities
- Add automated pytest unit test suite covering dispatcher and vet_common
- Modernize Terraform HCL definitions for gads_account_dispatcher and scheduler job